### PR TITLE
Fix displaing warning from DrawMaker()

### DIFF
--- a/library/natives/GTAV/GRAPHICS.lua
+++ b/library/natives/GTAV/GRAPHICS.lua
@@ -945,8 +945,8 @@ function DrawLowQualityPhotoToPhone(p0, p1) end
 ---@param faceCamera boolean
 ---@param p19 number
 ---@param rotate boolean
----@param textureDict string
----@param textureName string
+---@param textureDict string | nil
+---@param textureName string | nil
 ---@param drawOnEnts boolean
 function DrawMarker(type, posX, posY, posZ, dirX, dirY, dirZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ, red, green, blue, alpha, bobUpAndDown, faceCamera, p19, rotate, textureDict, textureName, drawOnEnts) end
 


### PR DESCRIPTION
When you don't want to use textures for marker, you should be able just to skip this param with passing nil. This will fix displaing warning from lua diagnostics on DrawMarker() native:
```
Cannot assign `nil` to parameter `string`.
- `nil` cannot match `string`
- Type `nil` cannot match `string`
```