### PR TITLE
Update WATER.lua RDR3

### DIFF
--- a/library/natives/RDR3/WATER.lua
+++ b/library/natives/RDR3/WATER.lua
@@ -16,8 +16,9 @@ function EnableWaterLookup() end
 ---@param x number
 ---@param y number
 ---@param z number
----@return boolean, number
-function GetWaterHeight(x, y, z) end
+---@param height number
+---@return boolean, number height
+function GetWaterHeight(x, y, z, height) end
 
 ---**`WATER` `client`**  
 ---[Native Documentation](https://alloc8or.re/rdr3/nativedb/?n=0xDCF3690AA262C03F)  


### PR DESCRIPTION
native requires 2 parameters according to decompiles, vector3 and float.
since in rdr3 natives, is passed as x,y,z  vector is ruled out. so there should be 4 parameters

also it seems to be irelevant as it returns the same value as the parameter? but might be needed to get a better result...