### PR TITLE
Vector Parameters

### DIFF
--- a/plugin.lua
+++ b/plugin.lua
@@ -46,5 +46,21 @@ function OnSetText(uri, text)
 		}
 	end
 
+	-- prevent "missing-parameter" diagnostic when using a vector in natives execution by destructing the vector into its components
+	for vecStart, vecParam, vecEnd, _, dimension in str_gmatch(text, '()([_%w]+)()%s*%-%-%[(=*)%[@vec([234])param%]%4%]') do
+		dimension = tonumber(dimension) --[[@as 2|3|4]]
+		local paramPattern = ('%s[%%d]'):format(vecParam)
+		local replacementParams = {}
+		for i = 1, dimension do
+			replacementParams[i] = paramPattern:format(i)
+		end
+		count = count + 1
+		diffs[count] = {
+			start  = vecStart,
+			finish = vecEnd-1,
+			text = table.concat(replacementParams, ',')
+		}
+	end
+
 	return diffs
 end

--- a/plugin.lua
+++ b/plugin.lua
@@ -47,7 +47,7 @@ function OnSetText(uri, text)
 	end
 
 	-- prevent "missing-parameter" diagnostic when using a vector in natives execution by destructing the vector into its components
-	for vecStart, vecParam, vecEnd, _, dimension in str_gmatch(text, '()([_%w]+)()%s*%-%-%[(=*)%[@vec([234])param%]%4%]') do
+	for vecStart, vecParam, vecEnd, _, dimension in str_gmatch(text, '()([%._%w]+)()%s*%-%-%[(=*)%[@vec([234])param%]%4%]') do
 		dimension = tonumber(dimension) --[[@as 2|3|4]]
 		local paramPattern = ('%s[%%d]'):format(vecParam)
 		local replacementParams = {}


### PR DESCRIPTION
Allow passing vector parameters to the natives by preventing `missing-parameter` diagnostic.  
Examples ([CFX Lua 5.4](https://github.com/citizenfx/fivem/blob/532618cb747e96aa483a3e6cf089cc2c449f8c46/code/components/citizen-scripting-lua/src/LuaScriptNatives.cpp#L292)):
```lua
local markers = {
    {
        type = 0,
        coords = vec3(1,2,3),
        rotation = vec3(0.75, 0.25, 1.0),
        scale = vec3(2.5, 2.5, 1.0),
        color = { r = 255, g = 255, b = 255, a = 255 }, -- rgba are integers (vector4 makes them floats which causes an unwanted behavior)
    },
    {
        type = 28,
        coords = vec3(1,2,3),
        rotation = vec3(0),
        scale = vec3(15),
        color = { r = 0, g = 255, b = 0, a = 100 },
    }
}

CreateThread(function ()
    local direction = vec3(0)
    while true do
        Wait(0)
        for _, marker in ipairs(markers) do
            DrawMarker(
                marker.type,
                marker.coords --[[@vec3param]],
                direction --[[@vec3param]],
                marker.rotation --[[@vec3param]],
                marker.scale --[[@vec3param]],
                -- this is the reason for this pull request, the above is readable, but this looks awful
                marker.color.r, marker.color.g, marker.color.b, marker.color.a,
                false, false, 2, false,
                nil, nil,
                false
            )
        end
    end
end)
```
```lua
CreateThread(function ()
    local spawnPoint = vector4(1,2,3,4)

    local playerPed = PlayerPedId()
    local lastCoords = GetEntityCoords(playerPed)
    SetEntityCoords(playerPed, spawnPoint.xyz--[[@vec3param]], false, false, false, false)
    SetEntityHeading(playerPed, spawnPoint.w)
    SetNewWaypoint(lastCoords.xy--[[@vec2param]])
end)
```