### PR TITLE
Allow export callbacks to return multiple values

### DIFF
--- a/library/runtime/event.lua
+++ b/library/runtime/event.lua
@@ -7,7 +7,7 @@ source = nil
 ---@field name string
 ---@field key integer
 
----@overload fun(name: string, method: fun(...): any)
+---@overload fun(name: string, method: fun(...): ...)
 exports = {}
 
 --- Trigger a coroutine when the event is called.


### PR DESCRIPTION
Updates the `exports` callback type from returning a single `any` to returning varargs.

This fixes false LLS warnings when an export returns multiple values, e.g.:

```lua
return false, "error message"
```